### PR TITLE
fix(#61): enforce conventional commits

### DIFF
--- a/.github/workflows/conventional-commit.yaml
+++ b/.github/workflows/conventional-commit.yaml
@@ -1,0 +1,13 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: webiny/action-conventional-commits@v1.1.0


### PR DESCRIPTION
Add a github workflow to check that commit messages use conventional commits