### PR TITLE
fix(#36): add top-level watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "turbo build",
     "clean": "turbo clean",
     "test": "jest",
-    "generate-types": "turbo generate-types"
+    "generate-types": "turbo generate-types",
+    "watch": "turbo run watch --parallel"
   },
   "keywords": [],
   "author": "Douglas Wade <douglas.b.wade@gmail.com>",

--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,9 @@
     "generate-types": {
       "outputs": ["packages/**/dist/**/*.d.ts"],
       "inputs": ["packages/**/src/**/*.ts"]
+    },
+    "watch": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
I found a reasonable solution here: https://github.com/vercel/turbo/issues/986#issuecomment-1091384632

To try it out: `yarn run watch` at the top level. Fixes #36 