### PR TITLE
fix(#198): Add eleventy-plugin docs on the website

### DIFF
--- a/packages/eleventy-plugin/README.md
+++ b/packages/eleventy-plugin/README.md
@@ -1,0 +1,3 @@
+# @tybalt/eleventy-plugin
+
+See [the website](https://doug-wade.github.io/tybalt/pages/eleventy-plugin) for details.

--- a/packages/website/components/sidebar.js
+++ b/packages/website/components/sidebar.js
@@ -1,6 +1,6 @@
 import { defineComponent, html } from '@tybalt/core';
 
-const PACKAGES = ['cli', 'core', 'test-utils', 'validator'];
+const PACKAGES = ['cli', 'core', 'eleventy-plugin', 'test-utils', 'validator'];
 
 defineComponent({
     name: 'tybalt-sidebar',

--- a/packages/website/pages/eleventy-plugin.md
+++ b/packages/website/pages/eleventy-plugin.md
@@ -1,0 +1,47 @@
+---
+layout: layout.html
+title: Tybalt test utils
+---
+
+## Installation
+
+Install the eleventy plugin with your favorite npm client
+
+```shell
+npm install --save-dev @tybalt/eleventy-plugin
+```
+
+## Getting Started
+
+First, go through the [11ty Getting Started guide](https://www.11ty.dev/docs/getting-started/).
+
+Next, you'll need to configure the plugin in `.eleventy.js` with the location of your component definitions
+
+```javascript
+const tybaltPlugin = require('@tybalt/eleventy-plugin');
+
+module.exports = function (eleventyConfig) {
+    eleventyConfig.addPlugin(tybaltPlugin, {
+        components: ['./components'],
+    });
+};
+```
+
+## Usage
+
+The plugin makes the components available for use on all of your pages. If you have a component defined like this
+
+```javascript
+defineComponent({
+    name: 'FooBarBaz',
+    props: {
+        value: {},
+    },
+});
+```
+
+You can use it on your index.html or page.md like any other html element
+
+```html
+<foo-bar-baz value="value"></foo-bar-baz>
+```


### PR DESCRIPTION
Adds a page to the website and a readme that redirects to it.