### PR TITLE
feat: use package.json version in tests (#310)

### DIFF
--- a/packages/cli/tst/index.test.ts
+++ b/packages/cli/tst/index.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from '@jest/globals';
 import child_process from 'node:child_process';
 import path from 'node:path';
+import packageJson from "../package.json"
 
 describe('cli', () => {
     it('should emit the version', () => {
         const binScriptPath = path.resolve(`${__dirname}/../src/index.ts`);
         const results = child_process.execSync(`npx ts-node-esm ${binScriptPath} --version`);
 
-        expect(results.toString()).toEqual('0.0.12\n');
+        expect(results.toString()).toEqual(`${packageJson.version}\n`);
     });
 });


### PR DESCRIPTION
Hi @doug-wade,

This PR addresses issue #310 by fetching the version from `package.json` for the tests. Please review.

Thanks!