### PR TITLE
feat: Add flag to allow overriding of port

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -7,11 +7,13 @@ export default ({ program }: CommandContext) => {
         .description('watch a component or components')
         .option('-e, --examples', 'whether to serve the examples', true)
         .option('-w, --website', 'whether to serve the website', true)
-        .action((options: { examples: boolean; website: boolean }) => {
+        .option('-p, --port <value>', 'which port to serve', '3000')
+        .action((options: { examples: boolean; website: boolean; port: string }) => {
             const server = bs.create();
-
+        
             bs.init({
                 server: './dist',
+                port: Number(options.port)
             });
 
             bs.reload('*.html');


### PR DESCRIPTION
Solves #371

Added a new port flag to override the default value of '3000'. Do I have to deal with checking if the port number is valid, or will BrowserSync handle it for us? (for example, setting port to something not between 1 and 65535, or using alphabets?)