### PR TITLE
fix(#405): Remove dashes in guide title

### DIFF
--- a/packages/website/components/sidebar.js
+++ b/packages/website/components/sidebar.js
@@ -17,7 +17,7 @@ defineComponent({
         const guideLis = GUIDES.map((guide) => {
             return html`
                 <li>
-                    <tybalt-link href="/pages/${guide}-guide">${guide} guide</tybalt-link>
+                    <tybalt-link href="/pages/${guide}-guide">${guide.replaceAll('-', ' ')}</tybalt-link>
                 </li>
             `;
         });


### PR DESCRIPTION
Fixes #405 

As per the previous discussion, I've also removed the word "guide", which is beyond the scope of #405, but removes the redundancy.