### PR TITLE
chore: Add coverage-final.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 packages/**/dist/
 packages/cli/out/
 coverage/
+coverage-final.json
 .turbo/
 *.out
 .yarn/


### PR DESCRIPTION
Saw this is untracked when you test `npm run combine-coverage`