### PR TITLE
chore(NOBUG): Go to v0.0.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tybalt",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "A toolkit for writing web components",
     "private": true,
     "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tybalt/cli",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "A command-line application for getting started with tybalt web components",
     "bin": {
         "tybalt": "dist/index.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tybalt/core",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "A library for writing web components",
     "module": "dist/mjs/index.js",
     "main": "dist/cjs/index.js",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tybalt/cypress",
-    "version": "0.0.1",
+    "version": "0.0.22",
     "description": "The end-to-end tests for the tybalt website",
     "main": "dist/index.js",
     "scripts": {

--- a/packages/eleventy-plugin-vanilla-example/package.json
+++ b/packages/eleventy-plugin-vanilla-example/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tybalt/eleventy-plugin-vanilla-example",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "An example of using @tybalt/eleventy-plugin with vanilla web components",
     "private": true,
     "scripts": {

--- a/packages/eleventy-plugin/package.json
+++ b/packages/eleventy-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tybalt/eleventy-plugin",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "A plugin for eleventy for serving web components",
     "main": ".eleventy.js",
     "scripts": {

--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tybalt/esbuild-plugin",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "An esbuild plugin for compiling tybalt web components",
     "exports": {
         ".": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tybalt/eslint-plugin",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "An eslint plugin for linting tybalt web components",
     "main": "dist/index.js",
     "scripts": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tybalt/example",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "An example of how to use tybalt components",
     "main": "index.js",
     "private": true,

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tybalt/parser",
-    "version": "0.0.16",
+    "version": "0.0.22",
     "description": "An library for parsing strings into other types",
     "main": "dist/index.js",
     "scripts": {

--- a/packages/test-utils-lit-example/package.json
+++ b/packages/test-utils-lit-example/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tybalt/test-utils-lit-example",
-    "version": "1.0.0",
+    "version": "0.0.22",
     "description": "",
     "main": "index.js",
     "private": true,

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tybalt/test-utils",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "A set of utilities for unit testing web components",
     "module": "dist/mjs/index.js",
     "main": "dist/cjs/index.js",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tybalt/validator",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "A library for performing asynchronous validations",
     "main": "dist/index.cjs",
     "module": "dist/index.mjs",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tybalt/website",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "The tybalt documentation website",
     "main": "index.js",
     "private": true,


### PR DESCRIPTION
I left `@tybalt/parser` behind on v0.0.16, causing the npm publish to fail, so we need to release a new version to get a clean publish that works end-to-end.